### PR TITLE
feat(security): 移除系统默认用户名和密码配置以提升安全性

### DIFF
--- a/packages/vtron/src/packages/computer/layout/desktop/LockDesktop.vue
+++ b/packages/vtron/src/packages/computer/layout/desktop/LockDesktop.vue
@@ -19,7 +19,7 @@ function loginSuccess() {
   //     lockClassName.value = 'screen-hide';
   //   }, 500);
 }
-const userName = ref(sys._options.login?.username || 'admin');
+const userName = ref(sys._options.login?.username || '');
 const userPassword = ref(sys._options.login?.password || '');
 async function onLogin() {
   if (loginCallback) {

--- a/packages/vtron/src/packages/kernel/system/initConfig.ts
+++ b/packages/vtron/src/packages/kernel/system/initConfig.ts
@@ -18,8 +18,8 @@ export const defaultConfig: SystemOptions = {
   userLocation: '/C/Users/',
   systemLocation: '/C/System/',
   login: {
-    username: localStorage.getItem('vtron-username') || 'admin',
-    password: 'admin',
+    username: localStorage.getItem('vtron-username') || '',
+    password: '',
     init: () => {
       return !localStorage.getItem('vtron-username');
     },


### PR DESCRIPTION
	•	从 LockDesktop.vue 文件中移除了默认用户名 'admin'。
	•	在 initConfig.ts 文件中将默认用户名和密码设置为空字符串。

变更原因：
当前系统登录时的默认用户名为 'admin'，且无法在初次登录时进行修改。这种配置可能会导致未授权访问的风险。本次改动的目标是提高系统安全性，移除默认的用户名和密码，并允许用户名和密码从外部传入，以减少潜在的安全隐患。

