### PR TITLE
调整按钮样式

### DIFF
--- a/packages/vtron/src/App.vue
+++ b/packages/vtron/src/App.vue
@@ -16,6 +16,7 @@ import testicon from './assets/终端.png';
 import TestButton from './apps/TestButton.vue';
 import VtronTest from './apps/VtronTest.vue';
 import VtronPerfTest from './apps/VtronPerfTest.vue';
+import TestUiButton from './apps/TestUiButton.vue';
 import { System, VtronFile, VtronComputer } from './packages/plug';
 import vtronLogoIcon from './assets/vtron-icon-nobg.png';
 import { Tray, Menu } from '@/packages/services';
@@ -101,6 +102,16 @@ const sys = new System({
       window: {
         content: VtronPerfTest,
         title: 'Vtron自动性能测试',
+        icon: testicon,
+        center: true,
+      },
+    },
+    {
+      name: 'Vtron测试UI-按钮',
+      icon: testicon,
+      window: {
+        content: TestUiButton,
+        title: 'Vtron测试UI-按钮',
         icon: testicon,
         center: true,
       },

--- a/packages/vtron/src/apps/TestUiButton.vue
+++ b/packages/vtron/src/apps/TestUiButton.vue
@@ -1,0 +1,19 @@
+<!--
+ * @Author: Jahv
+ * @LastEditTime: 2024-11-06 00:06:33
+ * @Description: 测试按钮
+-->
+<template>
+  <div class="outer" v-dragable>
+    <p style="padding: 10px">
+      <WinButtonVue @click="">Test</WinButtonVue>
+      <br />
+      <WinButtonVue @click="">Test111111111111</WinButtonVue>
+      <br />
+      <WinButtonVue @click="">长长长长长长长长长长长长长长长长长长</WinButtonVue>
+    </p>
+  </div>
+</template>
+<script lang="ts" setup>
+import { vDragable, WinButtonVue } from '@packages/plug';
+</script>

--- a/packages/vtron/src/packages/components/WinButton.vue
+++ b/packages/vtron/src/packages/components/WinButton.vue
@@ -24,13 +24,13 @@ defineProps({
   cursor: pointer;
   transition: all 0.1s;
   font-size: var(--ui-font-size);
-  width: var(--ui-button-width);
+  min-width: var(--ui-button-width);
   height: var(--ui-button-height);
   border-width: 1px;
   box-sizing: border-box;
   white-space: nowrap;
   &:hover {
-    border-width: 2px;
+    box-shadow: inset 0 0 0 1px var(--color-blue);
     border-color: var(--color-blue);
     background-color: var(--color-light-blue);
   }

--- a/packages/vtron/src/packages/computer/layout/desktop/LockDesktop.vue
+++ b/packages/vtron/src/packages/computer/layout/desktop/LockDesktop.vue
@@ -4,8 +4,8 @@
  * @Description: Need CodeReview
 -->
 <script lang="ts" setup>
-import { inject, ref } from 'vue';
 import { System } from '@packages/kernel';
+import { inject, ref } from 'vue';
 
 const sys = inject<System>('system')!;
 const loginCallback = sys._options.loginCallback;
@@ -14,19 +14,19 @@ const lockClassName = ref('screen-show');
 const alertMsg = ref('');
 
 function loginSuccess() {
-  //   lockClassName.value = 'screen-hidean';
-  //   setTimeout(() => {
-  //     lockClassName.value = 'screen-hide';
-  //   }, 500);
+  lockClassName.value = 'screen-hidean';
+  setTimeout(() => {
+    lockClassName.value = 'screen-hide';
+  }, 500);
 }
 const userName = ref(sys._options.login?.username || '');
 const userPassword = ref(sys._options.login?.password || '');
 async function onLogin() {
   if (loginCallback) {
     alertMsg.value = '等待确认';
-    
+
     const res = await loginCallback(userName.value, userPassword.value);
-    console.log(userName.value, userPassword.value,res);
+
     if (res) {
       loginSuccess();
     } else {
@@ -54,10 +54,16 @@ async function onLogin() {
       </span>
       <div class="username">
         <span class="ant-input-group">
-          <input placeholder="请输入用户名" autofocus class="ant-input" v-model="userName" />
+          <input
+            placeholder="请输入用户名"
+            autofocus
+            class="ant-input"
+            v-model="userName"
+            @keyup.enter="onLogin"
+          />
         </span>
       </div>
-      <span>
+      <div class="password">
         <span class="ant-input-group">
           <!---->
           <input
@@ -67,6 +73,7 @@ async function onLogin() {
             autofocus
             class="ant-input"
             v-model="userPassword"
+            @keyup.enter="onLogin"
           />
           <span class="ant-input-group-addon">
             <button class="ant-btn-primary" type="button" @click="onLogin">
@@ -89,7 +96,7 @@ async function onLogin() {
           </span>
         </span>
         <div class="tip">{{ alertMsg }}</div>
-      </span>
+      </div>
     </div>
   </div>
 </template>
@@ -144,18 +151,19 @@ async function onLogin() {
         font-size: 16px;
         outline: none;
         border: none;
+        flex-grow: 1;
       }
       .ant-btn-primary {
         color: #fff;
-        background: #1890ff;
+        background: #1890ffb3;
         border-color: #1890ff;
         border: none;
         text-shadow: 0 -1px 0 rgb(0 0 0 / 12%);
         box-shadow: 0 2px 0 rgb(0 0 0 / 5%);
-        height: 30px;
-        padding: 6.4px 15px;
+        height: 100%;
+        padding: 6.4px 8px;
         font-size: 16px;
-        border-radius: 2px;
+        border-radius: 0;
         transition: all 0.3s;
         cursor: pointer;
       }
@@ -174,12 +182,18 @@ async function onLogin() {
     .username {
       font-size: 30px;
       margin-bottom: 14px;
+      width: 100%;
+
+      input {
+        text-align: center;
+      }
     }
   }
   .tip {
     padding: 4px 0px;
     font-size: 12px;
     height: 30px;
+    text-align: center;
   }
 }
 
@@ -202,4 +216,3 @@ async function onLogin() {
   }
 }
 </style>
-../../../kernel/system

--- a/packages/vtron/src/packages/computer/mount/initEventListener.ts
+++ b/packages/vtron/src/packages/computer/mount/initEventListener.ts
@@ -24,7 +24,8 @@ function initSizeEvent(system: System) {
     'mousemove',
     throttle((e) => {
       system.emitEvent('system.mousemove', e);
-    }, 100)
+    }, 100),
+    { passive: true } // 声明事件监听器不会调用 preventDefault(),有助于浏览器优化性能
   );
 }
 

--- a/packages/vtron/src/packages/kernel/state/subStates/ContextMenuState.ts
+++ b/packages/vtron/src/packages/kernel/state/subStates/ContextMenuState.ts
@@ -1,8 +1,8 @@
 import { Menu } from '@/packages/services';
-import { ref } from 'vue';
+import { Ref, ref } from 'vue';
 
 export class ContextMenuState {
-  current = ref<Menu | null>(null);
+  public readonly current: Ref<Menu | null> = ref<Menu | null>(null);
   constructor() {}
   setContextMenu(menu: Menu | null) {
     this.current.value = menu;


### PR DESCRIPTION
我对 WinButton 组件的样式进行了调整，使用 box-shadow 替换了 border-width，以避免由于边框宽度变化引起的抖动。同时，我采用 min-width 替代 width，确保长文本按钮可以正常展示。