### PR TITLE
refactor(vtron): 更新 plug.ts 中的导出语句，帮助更多人

### DIFF
--- a/packages/vtron/src/packages/plug.ts
+++ b/packages/vtron/src/packages/plug.ts
@@ -17,7 +17,7 @@ export { System } from '@/packages/kernel/system';
 export { BrowserWindow, Dialog, Menu, MenuItem, Tray } from '@/packages/services';
 export { Notify } from '@/packages/services/notification/Notification';
 export * from '@/packages/util/Path';
-export type { SystemOptions } from '@packages/type/type';
+export * from '@packages/type/type';
 export { VtronComputer } from './computer';
 export {
   WinButtonVue,


### PR DESCRIPTION
- 将 type 的导出方式从单独导出改为通配符导出
- 优化了导出语句的结构，提高了代码的可读性和维护性